### PR TITLE
Fix Export API and some cleanup

### DIFF
--- a/lib/api_spec/generator.rb
+++ b/lib/api_spec/generator.rb
@@ -40,7 +40,6 @@ module ApiSpec
         send(nested_name) << obj
       end if base.nested_adder_name
     end
-
   end
 
   class Parameter < APIObject
@@ -54,16 +53,15 @@ module ApiSpec
     }
 
     init(self)
-
   end
 
   class Method < APIObject
 
     JSON_NAMES = {
-      name: "MethodName",
-      synopsis: "Synopsis",
-      http_method: "HTTPMethod",
-      uri: "URI"
+      name: 'MethodName',
+      synopsis: 'Synopsis',
+      http_method: 'HTTPMethod',
+      uri: 'URI'
     }
 
     self.nested_name = :parameters
@@ -71,13 +69,12 @@ module ApiSpec
     self.nested_class = Parameter
 
     init(self)
-
   end
 
   class Endpoint < APIObject
 
     JSON_NAMES = {
-      name: "name",
+      name: 'name'
     }
 
     self.nested_name = :methods
@@ -85,11 +82,9 @@ module ApiSpec
     self.nested_class = ApiSpec::Method
 
     init(self)
-
   end
 
   class Spec < APIObject
-
     class << self
       attr_accessor :endpoints
     end
@@ -97,7 +92,7 @@ module ApiSpec
     self.endpoints = []
 
     def self.to_hash
-      { 'endpoints' => endpoints.map { |endpoint| endpoint.to_hash } }
+      { 'endpoints' => endpoints.map(&:to_hash) }
     end
 
     def self.write_spec(path)

--- a/lib/api_spec/specs/basic_pages.rb
+++ b/lib/api_spec/specs/basic_pages.rb
@@ -3,10 +3,9 @@ class ApiSpec::Spec
   endpoint 'Basic Pages' do |bp|
 
     bp.method('Index') do |m|
-
-      m.synopsis = "Shows a list of the basic pages in the system"
-      m.http_method = "GET"
-      m.uri = "/sites/:site_slug/pages/basic_pages"
+      m.synopsis = 'Shows a list of the basic pages in the system'
+      m.http_method = 'GET'
+      m.uri = '/sites/:site_slug/pages/basic_pages'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -32,14 +31,12 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'maximum number of results to return'
       end
-
     end
 
     bp.method('Create') do |m|
-
-      m.synopsis = "Creates a basic page for a site"
-      m.http_method = "POST"
-      m.uri = "/sites/:site_slug/pages/basic_pages"
+      m.synopsis = 'Creates a basic page for a site'
+      m.http_method = 'POST'
+      m.uri = '/sites/:site_slug/pages/basic_pages'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -52,14 +49,12 @@ class ApiSpec::Spec
         p.type = 'json'
         p.description = 'a JSON representation of the new basic page'
       end
-
     end
 
     bp.method('Update') do |m|
-
-      m.synopsis = "Updates the attributes of a basic page"
-      m.http_method = "PUT"
-      m.uri = "/sites/:site_slug/pages/basic_pages/:id"
+      m.synopsis = 'Updates the attributes of a basic page'
+      m.http_method = 'PUT'
+      m.uri = '/sites/:site_slug/pages/basic_pages/:id'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -78,14 +73,12 @@ class ApiSpec::Spec
         p.type = 'json'
         p.description = 'JSON containing updates'
       end
-
     end
 
     bp.method('Destroy') do |m|
-
-      m.synopsis = "Removes a basic page"
-      m.http_method = "DELETE"
-      m.uri = "/sites/:site_slug/pages/basic_pages/:id"
+      m.synopsis = 'Removes a basic page'
+      m.http_method = 'DELETE'
+      m.uri = '/sites/:site_slug/pages/basic_pages/:id'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -98,9 +91,6 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'the ID of the basic page'
       end
-
     end
-
   end
-
 end

--- a/lib/api_spec/specs/blog_posts.rb
+++ b/lib/api_spec/specs/blog_posts.rb
@@ -3,10 +3,9 @@ class ApiSpec::Spec
   endpoint 'Blog Posts' do |bp|
 
     bp.method('Index') do |m|
-
-      m.synopsis = "Shows a list of blog's posts"
-      m.http_method = "GET"
-      m.uri = "/sites/:site_slug/pages/blogs/:id/posts"
+      m.synopsis = 'Shows a list of posts for a blog'
+      m.http_method = 'GET'
+      m.uri = '/sites/:site_slug/pages/blogs/:id/posts'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -38,14 +37,12 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'maximum number of results to return'
       end
-
     end
 
     bp.method('Match') do |m|
-
-      m.synopsis = "Find a blog post by its external id"
-      m.http_method = "GET"
-      m.uri = "/sites/:site_slug/pages/blogs/:id/match"
+      m.synopsis = 'Find a blog post by its external id'
+      m.http_method = 'GET'
+      m.uri = '/sites/:site_slug/pages/blogs/:id/match'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -65,14 +62,12 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'the external id of the post'
       end
-
     end
 
     bp.method('Create') do |m|
-
-      m.synopsis = "Creates a new blog post"
-      m.http_method = "POST"
-      m.uri = "/sites/:site_slug/pages/blogs/:blog_id/posts"
+      m.synopsis = 'Creates a new blog post'
+      m.http_method = 'POST'
+      m.uri = '/sites/:site_slug/pages/blogs/:blog_id/posts'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -92,14 +87,12 @@ class ApiSpec::Spec
         p.type = 'json'
         p.description = 'a JSON representation of the new post'
       end
-
     end
 
     bp.method('Update') do |m|
-
-      m.synopsis = "Updates the attributes of a blog post"
-      m.http_method = "PUT"
-      m.uri = "/sites/:site_slug/pages/blogs/:blog_id/posts/:blog_post_id"
+      m.synopsis = 'Updates the attributes of a blog post'
+      m.http_method = 'PUT'
+      m.uri = '/sites/:site_slug/pages/blogs/:blog_id/posts/:blog_post_id'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -125,14 +118,12 @@ class ApiSpec::Spec
         p.type = 'json'
         p.description = 'JSON containing updates'
       end
-
     end
 
     bp.method('Destroy') do |m|
-
-      m.synopsis = "Removes a blog post"
-      m.http_method = "DELETE"
-      m.uri = "/sites/:site_slug/pages/blogs/:blog_id/posts/:blog_post_id"
+      m.synopsis = 'Removes a blog post'
+      m.http_method = 'DELETE'
+      m.uri = '/sites/:site_slug/pages/blogs/:blog_id/posts/:blog_post_id'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -151,10 +142,6 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'the ID of the blog'
       end
-
-
     end
-
   end
-
 end

--- a/lib/api_spec/specs/blogs.rb
+++ b/lib/api_spec/specs/blogs.rb
@@ -3,10 +3,9 @@ class ApiSpec::Spec
   endpoint 'Blogs' do |bp|
 
     bp.method('Index') do |m|
-
-      m.synopsis = "Shows a list of all blogs"
-      m.http_method = "GET"
-      m.uri = "/sites/:site_slug/pages/blogs"
+      m.synopsis = 'Shows a list of all blogs'
+      m.http_method = 'GET'
+      m.uri = '/sites/:site_slug/pages/blogs'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -32,14 +31,12 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'maximum number of results to return'
       end
-
     end
 
     bp.method('Show') do |m|
-
-      m.synopsis = "Show the details of a blog"
-      m.http_method = "GET"
-      m.uri = "/sites/:site_slug/pages/blogs/:id"
+      m.synopsis = 'Show the details of a blog'
+      m.http_method = 'GET'
+      m.uri = '/sites/:site_slug/pages/blogs/:id'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -52,14 +49,12 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'the ID of the blog'
       end
-
     end
 
     bp.method('Create') do |m|
-
-      m.synopsis = "Creates a new blog"
-      m.http_method = "POST"
-      m.uri = "/sites/:site_slug/pages/blogs"
+      m.synopsis = 'Creates a new blog'
+      m.http_method = 'POST'
+      m.uri = '/sites/:site_slug/pages/blogs'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -73,14 +68,12 @@ class ApiSpec::Spec
         p.type = 'json'
         p.description = 'a JSON representation of the new blog'
       end
-
     end
 
     bp.method('Update') do |m|
-
-      m.synopsis = "Updates the attributes of a blog"
-      m.http_method = "PUT"
-      m.uri = "/sites/:site_slug/pages/blogs/:id"
+      m.synopsis = 'Updates the attributes of a blog'
+      m.http_method = 'PUT'
+      m.uri = '/sites/:site_slug/pages/blogs/:id'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -100,14 +93,12 @@ class ApiSpec::Spec
         p.type = 'json'
         p.description = 'JSON containing updates'
       end
-
     end
 
     bp.method('Destroy') do |m|
-
-      m.synopsis = "Removes a blog"
-      m.http_method = "DELETE"
-      m.uri = "/sites/:site_slug/pages/blogs/:id"
+      m.synopsis = 'Removes a blog'
+      m.http_method = 'DELETE'
+      m.uri = '/sites/:site_slug/pages/blogs/:id'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -120,9 +111,6 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'the ID of the blog'
       end
-
     end
-
   end
-
 end

--- a/lib/api_spec/specs/calendars.rb
+++ b/lib/api_spec/specs/calendars.rb
@@ -3,10 +3,9 @@ class ApiSpec::Spec
   endpoint 'Calendars' do |bp|
 
     bp.method('Index') do |m|
-
-      m.synopsis = "Shows a list of calendars"
-      m.http_method = "GET"
-      m.uri = "/sites/:site_slug/pages/calendars"
+      m.synopsis = 'Shows a list of calendars'
+      m.http_method = 'GET'
+      m.uri = '/sites/:site_slug/pages/calendars'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -32,14 +31,12 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'maximum number of results to return'
       end
-
     end
 
     bp.method('Show') do |m|
-
-      m.synopsis = "Show the details of a calendar"
-      m.http_method = "GET"
-      m.uri = "/sites/:site_slug/pages/calendars/:id"
+      m.synopsis = 'Show the details of a calendar'
+      m.http_method = 'GET'
+      m.uri = '/sites/:site_slug/pages/calendars/:id'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -52,14 +49,12 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'the ID of the calendar'
       end
-
     end
 
     bp.method('Create') do |m|
-
-      m.synopsis = "Creates a new calendar"
-      m.http_method = "POST"
-      m.uri = "/sites/:site_slug/pages/calendars"
+      m.synopsis = 'Creates a new calendar'
+      m.http_method = 'POST'
+      m.uri = '/sites/:site_slug/pages/calendars'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -73,14 +68,12 @@ class ApiSpec::Spec
         p.type = 'json'
         p.description = 'a JSON representation of the new calendar'
       end
-
     end
 
     bp.method('Update') do |m|
-
-      m.synopsis = "Updates the attributes of a calendar"
-      m.http_method = "PUT"
-      m.uri = "/sites/:site_slug/pages/calendars/:id"
+      m.synopsis = 'Updates the attributes of a calendar'
+      m.http_method = 'PUT'
+      m.uri = '/sites/:site_slug/pages/calendars/:id'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -100,14 +93,12 @@ class ApiSpec::Spec
         p.type = 'json'
         p.description = 'JSON containing updates'
       end
-
     end
 
     bp.method('Destroy') do |m|
-
-      m.synopsis = "Removes a calendar"
-      m.http_method = "DELETE"
-      m.uri = "/sites/:site_slug/pages/calendars/:id"
+      m.synopsis = 'Removes a calendar'
+      m.http_method = 'DELETE'
+      m.uri = '/sites/:site_slug/pages/calendars/:id'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -120,9 +111,6 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'the ID of the calendar'
       end
-
     end
-
   end
-
 end

--- a/lib/api_spec/specs/campaign_data.rb
+++ b/lib/api_spec/specs/campaign_data.rb
@@ -3,13 +3,9 @@ class ApiSpec::Spec
   endpoint 'Campaign Data' do |bp|
 
     bp.method('Show') do |m|
-
-      m.synopsis = "Shows campaign metadata about the nation"
-      m.http_method = "GET"
-      m.uri = "/campaign_data"
-
+      m.synopsis = 'Shows campaign metadata about the nation'
+      m.http_method = 'GET'
+      m.uri = '/campaign_data'
     end
-
   end
-
 end

--- a/lib/api_spec/specs/contacts.rb
+++ b/lib/api_spec/specs/contacts.rb
@@ -3,15 +3,14 @@ class ApiSpec::Spec
   endpoint 'Contacts' do |c|
 
     c.method('Index') do |m|
-
       m.synopsis = "View a paginated list of a person's contacts"
-      m.http_method = "GET"
-      m.uri = "/people/:person_id/contacts"
+      m.http_method = 'GET'
+      m.uri = '/people/:person_id/contacts'
 
       m.parameter('person_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'the person\'s ID'
+        p.description = "the person's ID"
       end
 
       m.parameter('__token') do |p|
@@ -32,19 +31,17 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'maximum number of results to return'
       end
-
     end
 
     c.method('Create') do |m|
-
-      m.synopsis = "Record a contact for a person"
-      m.http_method = "POST"
-      m.uri = "/people/:person_id/contacts"
+      m.synopsis = 'Record a contact for a person'
+      m.http_method = 'POST'
+      m.uri = '/people/:person_id/contacts'
 
       m.parameter('person_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'the person\'s ID'
+        p.description = "the person's ID"
       end
 
       m.parameter('body') do |p|
@@ -52,18 +49,14 @@ class ApiSpec::Spec
         p.type = 'json'
         p.description = 'a JSON representation of the new contact'
       end
-
     end
-
   end
 
   endpoint 'Contact Types' do |c|
-
     c.method('Index') do |m|
-
-      m.synopsis = "Returns paginated list of nation-defined contact types"
-      m.http_method = "GET"
-      m.uri = "/settings/contact_types"
+      m.synopsis = 'Returns paginated list of nation-defined contact types'
+      m.http_method = 'GET'
+      m.uri = '/settings/contact_types'
 
       m.parameter('__token') do |p|
         p.required = 'N'
@@ -83,28 +76,24 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'maximum number of results to return'
       end
-
     end
 
     c.method('Create') do |m|
-
-      m.synopsis = "Creates a new contact type"
-      m.http_method = "POST"
-      m.uri = "/settings/contact_types"
+      m.synopsis = 'Creates a new contact type'
+      m.http_method = 'POST'
+      m.uri = '/settings/contact_types'
 
       m.parameter('body') do |p|
         p.required = 'Y'
         p.type = 'json'
         p.description = 'a JSON representation of the new contact type'
       end
-
     end
 
     c.method('Update') do |m|
-
-      m.synopsis = "Updates an existing contact type"
-      m.http_method = "PUT"
-      m.uri = "/settings/contact_types/:id"
+      m.synopsis = 'Updates an existing contact type'
+      m.http_method = 'PUT'
+      m.uri = '/settings/contact_types/:id'
 
       m.parameter('id') do |p|
         p.required = 'Y'
@@ -117,39 +106,30 @@ class ApiSpec::Spec
         p.type = 'json'
         p.description = 'a JSON representation of the updates to make'
       end
-
     end
 
     c.method('Destroy') do |m|
-
-      m.synopsis = "Destroys a contact type"
-      m.http_method = "DELETE"
-      m.uri = "/settings/contact_types/:id"
+      m.synopsis = 'Destroys a contact type'
+      m.http_method = 'DELETE'
+      m.uri = '/settings/contact_types/:id'
 
       m.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
         p.description = 'the ID of the existing contact type'
       end
-
     end
 
     c.method('List Methods') do |m|
-
-      m.synopsis = "Lists all contact methods"
-      m.http_method = "GET"
-      m.uri = "/settings/contact_methods"
-
+      m.synopsis = 'Lists all contact methods'
+      m.http_method = 'GET'
+      m.uri = '/settings/contact_methods'
     end
 
     c.method('List Statuses') do |m|
-
-      m.synopsis = "Lists all contact status types"
-      m.http_method = "GET"
-      m.uri = "/settings/contact_statuses"
-
+      m.synopsis = 'Lists all contact status types'
+      m.http_method = 'GET'
+      m.uri = '/settings/contact_statuses'
     end
-
   end
-
 end

--- a/lib/api_spec/specs/donations.rb
+++ b/lib/api_spec/specs/donations.rb
@@ -3,9 +3,9 @@ class ApiSpec::Spec
   endpoint 'Donations' do |donation|
 
     donation.method('Index') do |method|
-      method.synopsis = "Returns a list of donations"
-      method.http_method = "GET"
-      method.uri = "/donations"
+      method.synopsis = 'Returns a list of donations'
+      method.http_method = 'GET'
+      method.uri = '/donations'
 
       method.parameter('__token') do |p|
         p.required = 'N'
@@ -28,27 +28,27 @@ class ApiSpec::Spec
     end
 
     donation.method('Create') do |method|
-      method.synopsis = "Creates a donation with the provided data"
-      method.http_method = "POST"
-      method.uri = "/donations"
+      method.synopsis = 'Creates a donation with the provided data'
+      method.http_method = 'POST'
+      method.uri = '/donations'
 
       method.parameter('body') do |p|
         p.required = 'Y'
         p.default = '{}'
         p.type = 'json'
-        p.description = 'JSON representation of a donation'
+        p.description = 'a JSON representation of a donation'
       end
     end
 
     donation.method('Update') do |method|
-      method.synopsis = "Updates a donation with the provided data"
-      method.http_method = "PUT"
-      method.uri = "/donations/:id"
+      method.synopsis = 'Updates a donation with the provided data'
+      method.http_method = 'PUT'
+      method.uri = '/donations/:id'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The donation's ID"
+        p.description = "the donation's ID"
       end
 
       method.parameter('body') do |p|
@@ -60,17 +60,15 @@ class ApiSpec::Spec
     end
 
     donation.method('Destroy') do |method|
-      method.synopsis = "Removes the donation with the matching ID"
-      method.http_method = "DELETE"
-      method.uri = "/donations/:id"
+      method.synopsis = 'Removes the donation with the matching ID'
+      method.http_method = 'DELETE'
+      method.uri = '/donations/:id'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The donation's ID"
+        p.description = "the donation's ID"
       end
     end
-
   end
-
 end

--- a/lib/api_spec/specs/events.rb
+++ b/lib/api_spec/specs/events.rb
@@ -3,9 +3,9 @@ class ApiSpec::Spec
   endpoint 'Events' do |event|
 
     event.method('Index') do |method|
-      method.synopsis = "Returns a list of events"
-      method.http_method = "GET"
-      method.uri = "/sites/:site_slug/pages/events"
+      method.synopsis = 'Returns a list of events'
+      method.http_method = 'GET'
+      method.uri = '/sites/:site_slug/pages/events'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -55,13 +55,12 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'the ID of the calendar from which events should be scoped'
       end
-
     end
 
     event.method('Show') do |method|
-      method.synopsis = "Returns an event"
-      method.http_method = "GET"
-      method.uri = "/sites/:site_slug/pages/events/:id"
+      method.synopsis = 'Returns an event'
+      method.http_method = 'GET'
+      method.uri = '/sites/:site_slug/pages/events/:id'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -72,15 +71,14 @@ class ApiSpec::Spec
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'the ID of the event'
+        p.description = "the event's ID"
       end
-
     end
 
     event.method('Create') do |method|
-      method.synopsis = "Creates a event with the provided data"
-      method.http_method = "POST"
-      method.uri = "/sites/:site_slug/pages/events"
+      method.synopsis = 'Creates a event with the provided data'
+      method.http_method = 'POST'
+      method.uri = '/sites/:site_slug/pages/events'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -97,9 +95,9 @@ class ApiSpec::Spec
     end
 
     event.method('Update') do |method|
-      method.synopsis = "Updates a event with the provided data"
-      method.http_method = "PUT"
-      method.uri = "/sites/:site_slug/pages/events/:id"
+      method.synopsis = 'Updates a event with the provided data'
+      method.http_method = 'PUT'
+      method.uri = '/sites/:site_slug/pages/events/:id'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -110,7 +108,7 @@ class ApiSpec::Spec
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The event's ID"
+        p.description = "the event's ID"
       end
 
       method.parameter('body') do |p|
@@ -122,9 +120,9 @@ class ApiSpec::Spec
     end
 
     event.method('Destroy') do |method|
-      method.synopsis = "Removes the event with the matching ID"
-      method.http_method = "DELETE"
-      method.uri = "/sites/:site_slug/pages/events/:id"
+      method.synopsis = 'Removes the event with the matching ID'
+      method.http_method = 'DELETE'
+      method.uri = '/sites/:site_slug/pages/events/:id'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -135,14 +133,14 @@ class ApiSpec::Spec
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The event's ID"
+        p.description = "the event's ID"
       end
     end
 
     event.method('RSVPs') do |method|
-      method.synopsis = "Lists all RSVPs for an event"
-      method.http_method = "GET"
-      method.uri = "/sites/:site_slug/pages/events/:id/rsvps"
+      method.synopsis = 'Lists all RSVPs for an event'
+      method.http_method = 'GET'
+      method.uri = '/sites/:site_slug/pages/events/:id/rsvps'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -153,7 +151,7 @@ class ApiSpec::Spec
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The event's ID"
+        p.description = "the event's ID"
       end
 
       method.parameter('__token') do |p|
@@ -174,13 +172,12 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'maximum number of results to return'
       end
-
     end
 
     event.method('RSVP Create') do |method|
-      method.synopsis = "Creates an RSVP for an event"
-      method.http_method = "POST"
-      method.uri = "/sites/:site_slug/pages/events/:id/rsvps"
+      method.synopsis = 'Creates an RSVP for an event'
+      method.http_method = 'POST'
+      method.uri = '/sites/:site_slug/pages/events/:id/rsvps'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -191,7 +188,7 @@ class ApiSpec::Spec
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The event's ID"
+        p.description = "the event's ID"
       end
 
       method.parameter('body') do |p|
@@ -199,13 +196,12 @@ class ApiSpec::Spec
         p.type = 'json'
         p.description = 'A JSON representation of the new post'
       end
-
     end
 
     event.method('RSVP Update') do |method|
-      method.synopsis = "Updates an existing RSVP"
-      method.http_method = "PUT"
-      method.uri = "/sites/:site_slug/pages/events/:event_id/rsvps/:rsvp_id"
+      method.synopsis = 'Updates an existing RSVP'
+      method.http_method = 'PUT'
+      method.uri = '/sites/:site_slug/pages/events/:event_id/rsvps/:rsvp_id'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -216,13 +212,13 @@ class ApiSpec::Spec
       method.parameter('event_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The event's ID"
+        p.description = "the event's ID"
       end
 
       method.parameter('rsvp_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The RSVP's ID"
+        p.description = "the RSVP's ID"
       end
 
       method.parameter('body') do |p|
@@ -230,9 +226,6 @@ class ApiSpec::Spec
         p.type = 'json'
         p.description = 'JSON attributes for updating the RSVP'
       end
-
     end
-
   end
-
 end

--- a/lib/api_spec/specs/exports.rb
+++ b/lib/api_spec/specs/exports.rb
@@ -2,10 +2,16 @@ class ApiSpec::Spec
 
   endpoint 'Exports' do |export|
 
-    export.method('Create List') do |method|
-      method.synopsis = "Creates a list export with the provided data"
-      method.http_method = "POST"
-      method.uri = "/list/:list_id/exports"
+    export.method('Export List') do |method|
+      method.synopsis = 'Starts an export of a list'
+      method.http_method = 'POST'
+      method.uri = '/lists/:list_id/exports'
+
+      method.parameter('list_id') do |p|
+        p.required = 'Y'
+        p.type = 'int'
+        p.description = 'ID of the list to export'
+      end
 
       method.parameter('body') do |p|
         p.required = 'Y'
@@ -15,9 +21,9 @@ class ApiSpec::Spec
     end
 
     export.method('Show') do |method|
-      method.synopsis = "Shows the status of a list export."
-      method.http_method = "GET"
-      method.uri = "/exports/:id"
+      method.synopsis = 'Shows the status of a list export.'
+      method.http_method = 'GET'
+      method.uri = '/exports/:id'
 
       method.parameter('id') do |p|
         p.required = 'Y'
@@ -27,9 +33,9 @@ class ApiSpec::Spec
     end
 
     export.method('Delete') do |method|
-      method.synopsis = "Delete the export"
-      method.http_method = "DELETE"
-      method.uri = "/exports/:id"
+      method.synopsis = 'Delete the export'
+      method.http_method = 'DELETE'
+      method.uri = '/exports/:id'
 
       method.parameter('id') do |p|
         p.required = 'Y'
@@ -38,5 +44,4 @@ class ApiSpec::Spec
       end
     end
   end
-
 end

--- a/lib/api_spec/specs/imports.rb
+++ b/lib/api_spec/specs/imports.rb
@@ -3,22 +3,21 @@ class ApiSpec::Spec
   endpoint 'Imports' do |import|
 
     import.method('Show') do |method|
-      method.synopsis = "Shows the status of an import"
-      method.http_method = "GET"
-      method.uri = "/imports/:id"
+      method.synopsis = 'Shows the status of an import'
+      method.http_method = 'GET'
+      method.uri = '/imports/:id'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
         p.description = 'the ID of the import'
       end
-
     end
 
     import.method('Create') do |method|
-      method.synopsis = "Creates a import with the provided data"
-      method.http_method = "POST"
-      method.uri = "/imports"
+      method.synopsis = 'Creates a import with the provided data'
+      method.http_method = 'POST'
+      method.uri = '/imports'
 
       method.parameter('body') do |p|
         p.required = 'Y'
@@ -28,9 +27,9 @@ class ApiSpec::Spec
     end
 
     import.method('Result') do |method|
-      method.synopsis = "Gets the import results and error csv file."
-      method.http_method = "GET"
-      method.uri = "/imports/:id/result"
+      method.synopsis = 'Gets the import results and error csv file.'
+      method.http_method = 'GET'
+      method.uri = '/imports/:id/result'
 
       method.parameter('id') do |p|
         p.required = 'Y'
@@ -39,5 +38,4 @@ class ApiSpec::Spec
       end
     end
   end
-
 end

--- a/lib/api_spec/specs/lists.rb
+++ b/lib/api_spec/specs/lists.rb
@@ -3,9 +3,9 @@ class ApiSpec::Spec
   endpoint 'Lists' do |lists|
 
     lists.method('Index') do |method|
-      method.synopsis = "Returns a list of created custom lists"
-      method.http_method = "GET"
-      method.uri = "/lists"
+      method.synopsis = 'Returns a list of created custom lists'
+      method.http_method = 'GET'
+      method.uri = '/lists'
 
       method.parameter('__token') do |p|
         p.required = 'N'
@@ -28,14 +28,14 @@ class ApiSpec::Spec
     end
 
     lists.method('People') do |method|
-      method.synopsis = "Returns people stored in a list"
-      method.http_method = "GET"
-      method.uri = "/lists/:id/people"
+      method.synopsis = 'Returns people stored in a list'
+      method.http_method = 'GET'
+      method.uri = '/lists/:id/people'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The list's ID"
+        p.description = "the list's ID"
       end
 
       method.parameter('__token') do |p|
@@ -59,27 +59,27 @@ class ApiSpec::Spec
     end
 
     lists.method('Create') do |method|
-      method.synopsis = "Creates a list with the provided data"
-      method.http_method = "POST"
-      method.uri = "/lists"
+      method.synopsis = 'Creates a list with the provided data'
+      method.http_method = 'POST'
+      method.uri = '/lists'
 
       method.parameter('body') do |p|
         p.required = 'Y'
         p.default = '{}'
         p.type = 'json'
-        p.description = 'JSON representation of the list to create'
+        p.description = 'a JSON representation of the list to create'
       end
     end
 
     lists.method('Update') do |method|
-      method.synopsis = "Updates a list with the provided data"
-      method.http_method = "PUT"
-      method.uri = "/lists/:id"
+      method.synopsis = 'Updates a list with the provided data'
+      method.http_method = 'PUT'
+      method.uri = '/lists/:id'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The list's ID"
+        p.description = "the list's ID"
       end
 
       method.parameter('body') do |p|
@@ -91,26 +91,26 @@ class ApiSpec::Spec
     end
 
     lists.method('Destroy') do |method|
-      method.synopsis = "Removes the list with the matching ID"
-      method.http_method = "DELETE"
-      method.uri = "/lists/:id"
+      method.synopsis = 'Removes the list with the matching ID'
+      method.http_method = 'DELETE'
+      method.uri = '/lists/:id'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The list's ID"
+        p.description = "the list's ID"
       end
     end
 
     lists.method('Add people') do |method|
-      method.synopsis = "Adds people to a list"
-      method.http_method = "POST"
-      method.uri = "/lists/:list_id/people"
+      method.synopsis = 'Adds people to a list'
+      method.http_method = 'POST'
+      method.uri = '/lists/:list_id/people'
 
       method.parameter('list_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The ID of the list'
+        p.description = "the list's ID"
       end
 
       method.parameter('body') do |p|
@@ -121,14 +121,14 @@ class ApiSpec::Spec
     end
 
     lists.method('Destroy people') do |method|
-      method.synopsis = "Removes people from a list"
-      method.http_method = "DELETE"
-      method.uri = "/lists/:list_id/people"
+      method.synopsis = 'Removes people from a list'
+      method.http_method = 'DELETE'
+      method.uri = '/lists/:list_id/people'
 
       method.parameter('list_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The ID of the list'
+        p.description = "the list's ID"
       end
 
       method.parameter('body') do |p|
@@ -139,77 +139,75 @@ class ApiSpec::Spec
     end
 
     lists.method('Listing Create (deprecated)') do |method|
-      method.synopsis = "Adds a person to a list"
-      method.http_method = "POST"
-      method.uri = "/lists/:list_id/listings"
+      method.synopsis = 'Adds a person to a list'
+      method.http_method = 'POST'
+      method.uri = '/lists/:list_id/listings'
 
       method.parameter('list_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The ID of the list'
+        p.description = "the list's ID"
       end
 
       method.parameter('person_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The ID of the person to add to the list'
+        p.description = 'the ID of the person to add to the list'
       end
     end
 
     lists.method('Listing Deletion (deprecated)') do |method|
-      method.synopsis = "Drops a person from a list"
-      method.http_method = "DELETE"
-      method.uri = "/lists/:list_id/listings/:person_id"
+      method.synopsis = 'Drops a person from a list'
+      method.http_method = 'DELETE'
+      method.uri = '/lists/:list_id/listings/:person_id'
 
       method.parameter('list_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The ID of the list'
+        p.description = "the list's ID"
       end
 
       method.parameter('person_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The ID of the person to drop from the list'
+        p.description = 'the ID of the person to drop from the list'
       end
     end
 
     lists.method('Add tag') do |method|
-      method.synopsis = "Adds a tag to all of the list members"
-      method.http_method = "POST"
-      method.uri = "/lists/:list_id/tag/:tag"
+      method.synopsis = 'Adds a tag to all of the list members'
+      method.http_method = 'POST'
+      method.uri = '/lists/:list_id/tag/:tag'
 
       method.parameter('list_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The ID of the list'
+        p.description = "the list's ID"
       end
 
       method.parameter('tag') do |p|
         p.required = 'Y'
         p.type = 'string'
-        p.description = 'The name of the tag to use'
+        p.description = 'the name of the tag to use'
       end
     end
 
     lists.method('Delete tag') do |method|
-      method.synopsis = "Deletes the tag from all of the list members"
-      method.http_method = "DELETE"
-      method.uri = "/lists/:list_id/tag/:tag"
+      method.synopsis = 'Deletes the tag from all of the list members'
+      method.http_method = 'DELETE'
+      method.uri = '/lists/:list_id/tag/:tag'
 
       method.parameter('list_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The ID of the list'
+        p.description = "the list's ID"
       end
 
       method.parameter('tag') do |p|
         p.required = 'Y'
         p.type = 'string'
-        p.description = 'The name of the tag to use'
+        p.description = 'the name of the tag to use'
       end
     end
-
   end
-
 end

--- a/lib/api_spec/specs/memberships.rb
+++ b/lib/api_spec/specs/memberships.rb
@@ -1,7 +1,7 @@
 class ApiSpec::Spec
 
   endpoint 'Memberships' do |memberships|
-
+    
     memberships.method('Index') do |method|
       method.synopsis = 'Lists all memberships for a person'
       method.http_method = 'GET'
@@ -10,7 +10,7 @@ class ApiSpec::Spec
       method.parameter('person_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The person\'s ID'
+        p.description = "the person's ID"
       end
 
       method.parameter('__token') do |p|
@@ -41,7 +41,7 @@ class ApiSpec::Spec
       method.parameter('person_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The person\'s ID'
+        p.description = "the person's ID"
       end
 
       method.parameter('body') do |p|
@@ -60,7 +60,7 @@ class ApiSpec::Spec
       method.parameter('person_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The person\'s ID'
+        p.description = "the person's ID"
       end
 
       method.parameter('body') do |p|
@@ -79,16 +79,14 @@ class ApiSpec::Spec
       method.parameter('person_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The person\'s ID'
+        p.description = "the person's ID"
       end
 
       method.parameter('name') do |p|
         p.required = 'Y'
         p.type = 'string'
-        p.description = 'The name of the membership'
+        p.description = 'the name of the membership'
       end
     end
-
   end
-
 end

--- a/lib/api_spec/specs/page_attachments.rb
+++ b/lib/api_spec/specs/page_attachments.rb
@@ -4,20 +4,20 @@ class ApiSpec::Spec
 
     pa.method('Index') do |method|
       method.synopsis = "Returns a list of a page's file attachments"
-      method.http_method = "GET"
-      method.uri = "/sites/:site_slug/pages/:page_slug/attachments"
+      method.http_method = 'GET'
+      method.uri = '/sites/:site_slug/pages/:page_slug/attachments'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
         p.type = 'string'
-        p.description = 'The slug of the site the page lives on'
+        p.description = 'the slug of the site the page lives on'
       end
 
       method.parameter('page_slug') do |p|
         p.required = 'Y'
         p.default = '1'
         p.type = 'string'
-        p.description = 'The page\'s slug'
+        p.description = "the page's slug"
       end
 
       method.parameter('__token') do |p|
@@ -41,81 +41,79 @@ class ApiSpec::Spec
     end
 
     pa.method('Show') do |method|
-      method.synopsis = "Creates a new file attachment for a page"
-      method.http_method = "GET"
-      method.uri = "/sites/:site_slug/pages/:page_slug/attachments/:id"
+      method.synopsis = 'Creates a new file attachment for a page'
+      method.http_method = 'GET'
+      method.uri = '/sites/:site_slug/pages/:page_slug/attachments/:id'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
         p.type = 'string'
-        p.description = 'The slug of the site the page lives on'
+        p.description = 'the slug of the site the page lives on'
       end
 
       method.parameter('page_slug') do |p|
         p.required = 'Y'
         p.default = '1'
         p.type = 'string'
-        p.description = 'The page\'s slug'
+        p.description = "the page's slug"
       end
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The ID of the page attachment'
+        p.description = 'the ID of the page attachment'
       end
     end
 
     pa.method('Create') do |method|
-      method.synopsis = "Creates a new file attachment for a page"
-      method.http_method = "POST"
-      method.uri = "/sites/:site_slug/pages/:page_slug/attachments"
+      method.synopsis = 'Creates a new file attachment for a page'
+      method.http_method = 'POST'
+      method.uri = '/sites/:site_slug/pages/:page_slug/attachments'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
         p.type = 'string'
-        p.description = 'The slug of the site the page lives on'
+        p.description = 'the slug of the site the page lives on'
       end
 
       method.parameter('page_slug') do |p|
         p.required = 'Y'
         p.default = '1'
         p.type = 'string'
-        p.description = 'The page\'s slug'
+        p.description = "the page's slug"
       end
 
       method.parameter('body') do |p|
         p.required = 'Y'
         p.default = '{}'
         p.type = 'json'
-        p.description = 'A JSON representation of the attachment'
+        p.description = 'a JSON representation of the attachment'
       end
     end
 
     pa.method('Destroy') do |method|
-      method.synopsis = "Destroys a file attachment for a page"
-      method.http_method = "DELETE"
-      method.uri = "/sites/:site_slug/pages/:page_slug/attachments/:id"
+      method.synopsis = 'Destroys a file attachment for a page'
+      method.http_method = 'DELETE'
+      method.uri = '/sites/:site_slug/pages/:page_slug/attachments/:id'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
         p.type = 'string'
-        p.description = 'The slug of the site the page lives on'
+        p.description = 'the slug of the site the page lives on'
       end
 
       method.parameter('page_slug') do |p|
         p.required = 'Y'
         p.default = '1'
         p.type = 'string'
-        p.description = 'The page\'s slug'
+        p.description = "the page's slug"
       end
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'The ID of the page attachment'
+        p.description = 'the ID of the page attachment'
       end
     end
-
   end
-
 end

--- a/lib/api_spec/specs/people.rb
+++ b/lib/api_spec/specs/people.rb
@@ -3,9 +3,9 @@ class ApiSpec::Spec
   endpoint 'People' do |people|
 
     people.method('Index') do |method|
-      method.synopsis = "Returns a list of people"
-      method.http_method = "GET"
-      method.uri = "/people"
+      method.synopsis = 'Returns a list of people'
+      method.http_method = 'GET'
+      method.uri = '/people'
 
       method.parameter('__token') do |p|
         p.required = 'N'
@@ -28,106 +28,105 @@ class ApiSpec::Spec
     end
 
     people.method('Count') do |method|
-      method.synopsis = "Returns a count of people in the nation"
-      method.http_method = "GET"
-      method.uri = "/people/count"
+      method.synopsis = 'Returns a count of people in the nation'
+      method.http_method = 'GET'
+      method.uri = '/people/count'
     end
 
     people.method('Show') do |method|
-      method.synopsis = "Returns a full representation of the person"
-      method.http_method = "GET"
-      method.uri = "/people/:id"
+      method.synopsis = 'Returns a full representation of the person'
+      method.http_method = 'GET'
+      method.uri = '/people/:id'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.default = '1'
         p.type = 'int'
-        p.description = 'the person\'s id'
+        p.description = "the person's id"
       end
     end
 
     people.method('Match') do |method|
-      method.synopsis = "Finds people that match certain attributes exactly"
-      method.http_method = "GET"
-      method.uri = "/people/match"
+      method.synopsis = 'Finds people that match certain attributes exactly'
+      method.http_method = 'GET'
+      method.uri = '/people/match'
 
-      method.parameter("email") do |p|
+      method.parameter('email') do |p|
         p.required = 'N'
         p.type = 'string'
       end
 
-      method.parameter("first_name") do |p|
-        p.required = 'N'
-        p.type = 'string'
-        p.description = 'deprecated'
-      end
-
-      method.parameter("last_name") do |p|
+      method.parameter('first_name') do |p|
         p.required = 'N'
         p.type = 'string'
         p.description = 'deprecated'
       end
 
-      method.parameter("phone") do |p|
+      method.parameter('last_name') do |p|
         p.required = 'N'
         p.type = 'string'
         p.description = 'deprecated'
       end
 
-      method.parameter("mobile") do |p|
+      method.parameter('phone') do |p|
         p.required = 'N'
         p.type = 'string'
         p.description = 'deprecated'
       end
 
+      method.parameter('mobile') do |p|
+        p.required = 'N'
+        p.type = 'string'
+        p.description = 'deprecated'
+      end
     end
 
     people.method('Search') do |method|
-      method.synopsis = "Search for people using non-unique traits"
-      method.http_method = "GET"
-      method.uri = "/people/search"
+      method.synopsis = 'Search for people using non-unique traits'
+      method.http_method = 'GET'
+      method.uri = '/people/search'
 
-      method.parameter("first_name") do |p|
+      method.parameter('first_name') do |p|
         p.required = 'N'
         p.type = 'string'
       end
 
-      method.parameter("last_name") do |p|
+      method.parameter('last_name') do |p|
         p.required = 'N'
         p.type = 'string'
       end
 
-      method.parameter("city") do |p|
+      method.parameter('city') do |p|
         p.required = 'N'
         p.type = 'string'
       end
 
-      method.parameter("state") do |p|
+      method.parameter('state') do |p|
         p.required = 'N'
         p.type = 'string'
       end
 
-      method.parameter("sex") do |p|
+      method.parameter('sex') do |p|
         p.required = 'N'
         p.type = 'string'
       end
 
-      method.parameter("birthdate") do |p|
+      method.parameter('birthdate') do |p|
         p.required = 'N'
         p.type = 'string'
       end
 
-      method.parameter("updated_since") do |p|
+      method.parameter('updated_since') do |p|
         p.required = 'N'
         p.type = 'string'
       end
 
-      method.parameter("with_mobile") do |p|
+      method.parameter('with_mobile') do |p|
         p.required = 'N'
         p.type = 'string'
       end
 
-      method.parameter("custom_values") do |p|
+      method.parameter('custom_values') do |p|
         p.required = 'N'
         p.type = 'string'
       end
@@ -223,15 +222,15 @@ class ApiSpec::Spec
     end
 
     people.method('Nearby') do |method|
-      method.synopsis = "Searches for people near a location defined by latitude and longitude"
-      method.http_method = "GET"
-      method.uri = "/people/nearby"
+      method.synopsis = 'Searches for people near a location defined by latitude and longitude'
+      method.http_method = 'GET'
+      method.uri = '/people/nearby'
 
       method.parameter('location') do |p|
         p.required = 'Y'
         p.default = '34.049031,-118.251399'
         p.type = 'string'
-        p.description = 'origin of search in the format "latitude,longitude"'
+        p.description = "origin of search in the format 'latitude,longitude'"
       end
 
       method.parameter('distance') do |p|
@@ -263,43 +262,43 @@ class ApiSpec::Spec
 
     people.method('Me') do |method|
       method.synopsis = "Returns the access token's resource owner's representation"
-      method.http_method = "GET"
-      method.uri = "/people/me"
+      method.http_method = 'GET'
+      method.uri = '/people/me'
     end
 
     people.method('Register') do |method|
-      method.synopsis = "Starts user registration person for the given person"
-      method.http_method = "GET"
-      method.uri = "/people/:id/register"
+      method.synopsis = 'Starts user registration person for the given person'
+      method.http_method = 'GET'
+      method.uri = '/people/:id/register'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The person's ID"
+        p.description = "the person's id"
       end
     end
 
     people.method('Taggings') do |method|
-      method.synopsis = "Returns all taggings for a given person"
-      method.http_method = "GET"
-      method.uri = "/people/:id/taggings"
+      method.synopsis = 'Returns all taggings for a given person'
+      method.http_method = 'GET'
+      method.uri = '/people/:id/taggings'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'the ID of the person'
+        p.description = "the person's id"
       end
     end
 
     people.method('Tag Person') do |method|
-      method.synopsis = "Tags a person"
-      method.http_method = "PUT"
-      method.uri = "/people/:id/taggings"
+      method.synopsis = 'Tags a person'
+      method.http_method = 'PUT'
+      method.uri = '/people/:id/taggings'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'the ID of the person'
+        p.description = "the person's id"
       end
 
       method.parameter('body') do |p|
@@ -310,14 +309,14 @@ class ApiSpec::Spec
     end
 
     people.method('Tag Removal') do |method|
-      method.synopsis = "Removes a tag from a person"
-      method.http_method = "DELETE"
-      method.uri = "/people/:id/taggings/:tag"
+      method.synopsis = 'Removes a tag from a person'
+      method.http_method = 'DELETE'
+      method.uri = '/people/:id/taggings/:tag'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'the ID of the person'
+        p.description = "the person's ID"
       end
 
       method.parameter('tag') do |p|
@@ -325,18 +324,17 @@ class ApiSpec::Spec
         p.type = 'string'
         p.description = 'the name of the tag'
       end
-
     end
 
     people.method('Bulk Tag Removal') do |method|
-      method.synopsis = "Removes tags from a person"
-      method.http_method = "DELETE"
-      method.uri = "/people/:id/taggings"
+      method.synopsis = 'Removes tags from a person'
+      method.http_method = 'DELETE'
+      method.uri = '/people/:id/taggings'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'the ID of the person'
+        p.description = "the person's ID"
       end
 
       method.parameter('body') do |p|
@@ -348,13 +346,13 @@ class ApiSpec::Spec
 
     people.method('Political Capital') do |method|
       method.synopsis = "Returns a paginated list of a person's capitals"
-      method.http_method = "GET"
-      method.uri = "/people/:id/capitals"
+      method.http_method = 'GET'
+      method.uri = '/people/:id/capitals'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "the ID of the person"
+        p.description = "the person's ID"
       end
 
       method.parameter('__token') do |p|
@@ -378,14 +376,14 @@ class ApiSpec::Spec
     end
 
     people.method('Political Capital Create') do |method|
-      method.synopsis = "Creates capital for the given person"
-      method.http_method = "POST"
-      method.uri = "/people/:id/capitals"
+      method.synopsis = 'Creates capital for the given person'
+      method.http_method = 'POST'
+      method.uri = '/people/:id/capitals'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "the ID of the person"
+        p.description = "the person's ID"
       end
 
       method.parameter('body') do |p|
@@ -396,14 +394,14 @@ class ApiSpec::Spec
     end
 
     people.method('Political Capital Destroy') do |method|
-      method.synopsis = "Destroys capital for a person"
-      method.http_method = "DELETE"
-      method.uri = "/people/:person_id/capitals/:capital_id"
+      method.synopsis = 'Destroys capital for a person'
+      method.http_method = 'DELETE'
+      method.uri = '/people/:person_id/capitals/:capital_id'
 
       method.parameter('person_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'the ID of the person'
+        p.description = "the person's ID"
       end
 
       method.parameter('capital_id') do |p|
@@ -414,27 +412,27 @@ class ApiSpec::Spec
     end
 
     people.method('Create') do |method|
-      method.synopsis = "Creates a person with the provided data"
-      method.http_method = "POST"
-      method.uri = "/people"
+      method.synopsis = 'Creates a person with the provided data'
+      method.http_method = 'POST'
+      method.uri = '/people'
 
       method.parameter('body') do |p|
         p.required = 'Y'
         p.default = '{}'
         p.type = 'json'
-        p.description = 'JSON representation of the person to create'
+        p.description = 'a JSON representation of the person to create'
       end
     end
 
     people.method('Update') do |method|
-      method.synopsis = "Updates a person with the provided data"
-      method.http_method = "PUT"
-      method.uri = "/people/:id"
+      method.synopsis = 'Updates a person with the provided data'
+      method.http_method = 'PUT'
+      method.uri = '/people/:id'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The person's ID"
+        p.description = "the person's ID"
       end
 
       method.parameter('body') do |p|
@@ -447,8 +445,8 @@ class ApiSpec::Spec
 
     people.method('Push') do |method|
       method.synopsis = "Updates a matched person or creates a new one if the person doesn't exist"
-      method.http_method = "PUT"
-      method.uri = "/people/push"
+      method.http_method = 'PUT'
+      method.uri = '/people/push'
 
       method.parameter('body') do |p|
         p.required = 'Y'
@@ -460,8 +458,8 @@ class ApiSpec::Spec
 
     people.method('Add') do |method|
       method.synopsis = "Updates a matched person (without overriding data) or creates a new one if the person doesn't exist"
-      method.http_method = "PUT"
-      method.uri = "/people/add"
+      method.http_method = 'PUT'
+      method.uri = '/people/add'
 
       method.parameter('body') do |p|
         p.required = 'Y'
@@ -472,35 +470,33 @@ class ApiSpec::Spec
     end
 
     people.method('Destroy') do |method|
-      method.synopsis = "Removes the person with the matching ID"
-      method.http_method = "DELETE"
-      method.uri = "/people/:id"
+      method.synopsis = 'Removes the person with the matching ID'
+      method.http_method = 'DELETE'
+      method.uri = '/people/:id'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The person's ID"
+        p.description = "the person's ID"
       end
     end
 
     people.method('Private Note Create') do |method|
-      method.synopsis = "Creates a private note for the given person"
-      method.http_method = "POST"
-      method.uri = "/people/:id/notes"
+      method.synopsis = 'Creates a private note for the given person'
+      method.http_method = 'POST'
+      method.uri = '/people/:id/notes'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "the ID of the person"
+        p.description = "the person's ID"
       end
 
       method.parameter('body') do |p|
         p.required = 'Y'
         p.type = 'json'
-        p.description = 'JSON representation of the note to create'
+        p.description = 'a JSON representation of the note to create'
       end
     end
-
   end
-
 end

--- a/lib/api_spec/specs/people_tags.rb
+++ b/lib/api_spec/specs/people_tags.rb
@@ -3,9 +3,9 @@ class ApiSpec::Spec
   endpoint 'People Tags' do |tags|
 
     tags.method('Index') do |method|
-      method.synopsis = "Returns a list of previously used tags"
-      method.http_method = "GET"
-      method.uri = "/tags"
+      method.synopsis = 'Returns a list of previously used tags'
+      method.http_method = 'GET'
+      method.uri = '/tags'
 
       method.parameter('__token') do |p|
         p.required = 'N'
@@ -28,9 +28,9 @@ class ApiSpec::Spec
     end
 
     tags.method('People') do |method|
-      method.synopsis = "Searches for people with the given tag"
-      method.http_method = "GET"
-      method.uri = "/tags/:tag/people"
+      method.synopsis = 'Searches for people with the given tag'
+      method.http_method = 'GET'
+      method.uri = '/tags/:tag/people'
 
       method.parameter('tag') do |p|
         p.required = 'Y'
@@ -57,7 +57,5 @@ class ApiSpec::Spec
         p.description = 'maximum number of results to return'
       end
     end
-
   end
-
 end

--- a/lib/api_spec/specs/precincts.rb
+++ b/lib/api_spec/specs/precincts.rb
@@ -3,9 +3,9 @@ class ApiSpec::Spec
   endpoint 'Precincts' do |precinct|
 
     precinct.method('Index') do |method|
-      method.synopsis = "Returns a list of current precincts"
-      method.http_method = "GET"
-      method.uri = "/precincts"
+      method.synopsis = 'Returns a list of current precincts'
+      method.http_method = 'GET'
+      method.uri = '/precincts'
 
       method.parameter('__token') do |p|
         p.required = 'N'
@@ -28,40 +28,40 @@ class ApiSpec::Spec
     end
 
     precinct.method('Show') do |method|
-      method.synopsis = "Returns a representation of the precinct"
-      method.http_method = "GET"
-      method.uri = "/precincts/:id"
+      method.synopsis = 'Returns a representation of the precinct'
+      method.http_method = 'GET'
+      method.uri = '/precincts/:id'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.default = '1'
         p.type = 'int'
-        p.description = "the precinct's id"
+        p.description = "the precinct's ID"
       end
     end
 
     precinct.method('Create') do |method|
-      method.synopsis = "Creates a precinct with the provided data"
-      method.http_method = "POST"
-      method.uri = "/precincts"
+      method.synopsis = 'Creates a precinct with the provided data'
+      method.http_method = 'POST'
+      method.uri = '/precincts'
 
       method.parameter('body') do |p|
         p.required = 'Y'
         p.default = '{}'
         p.type = 'json'
-        p.description = 'JSON representation of the precinct to create'
+        p.description = 'a JSON representation of the precinct to create'
       end
     end
 
     precinct.method('Update') do |method|
-      method.synopsis = "Updates a precinct with the provided data"
-      method.http_method = "PUT"
-      method.uri = "/precincts/:id"
+      method.synopsis = 'Updates a precinct with the provided data'
+      method.http_method = 'PUT'
+      method.uri = '/precincts/:id'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The precinct's ID"
+        p.description = "the precinct's ID"
       end
 
       method.parameter('body') do |p|
@@ -73,17 +73,15 @@ class ApiSpec::Spec
     end
 
     precinct.method('Destroy') do |method|
-      method.synopsis = "Removes the precinct with the matching ID"
-      method.http_method = "DELETE"
-      method.uri = "/precincts/:id"
+      method.synopsis = 'Removes the precinct with the matching ID'
+      method.http_method = 'DELETE'
+      method.uri = '/precincts/:id'
 
       method.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = "The precinct's ID"
+        p.description = "the precinct's ID"
       end
     end
-
   end
-
 end

--- a/lib/api_spec/specs/sites.rb
+++ b/lib/api_spec/specs/sites.rb
@@ -3,9 +3,9 @@ class ApiSpec::Spec
   endpoint 'Sites' do |tags|
 
     tags.method('Index') do |method|
-      method.synopsis = "Returns a list of all sites"
-      method.http_method = "GET"
-      method.uri = "/sites"
+      method.synopsis = 'Returns a list of all sites'
+      method.http_method = 'GET'
+      method.uri = '/sites'
 
       method.parameter('__token') do |p|
         p.required = 'N'
@@ -26,7 +26,5 @@ class ApiSpec::Spec
         p.description = 'maximum number of results to return'
       end
     end
-
   end
-
 end

--- a/lib/api_spec/specs/survey_responses.rb
+++ b/lib/api_spec/specs/survey_responses.rb
@@ -3,10 +3,9 @@ class ApiSpec::Spec
   endpoint 'Survey Responses' do |surveys|
 
     surveys.method('Index') do |m|
-
-      m.synopsis = "Lists all survey responses"
-      m.http_method = "GET"
-      m.uri = "/survey_responses"
+      m.synopsis = 'Lists all survey responses'
+      m.http_method = 'GET'
+      m.uri = '/survey_responses'
 
       m.parameter('start_time') do |p|
         p.required = 'N'
@@ -23,7 +22,7 @@ class ApiSpec::Spec
       m.parameter('survey_id') do |p|
         p.required = 'N'
         p.type = 'int'
-        p.description = 'the id for a parent survey'
+        p.description = 'the ID for a parent survey'
       end
 
       m.parameter('__token') do |p|
@@ -44,13 +43,12 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'maximum number of results to return'
       end
-
     end
 
     surveys.method('Create') do |m|
-      m.synopsis = "Creates responses for a survey"
-      m.http_method = "POST"
-      m.uri = "/survey_responses"
+      m.synopsis = 'Creates responses for a survey'
+      m.http_method = 'POST'
+      m.uri = '/survey_responses'
 
       m.parameter('body') do |p|
         p.required = 'Y'
@@ -59,6 +57,4 @@ class ApiSpec::Spec
       end
     end
   end
-
-
 end

--- a/lib/api_spec/specs/surveys.rb
+++ b/lib/api_spec/specs/surveys.rb
@@ -3,10 +3,9 @@ class ApiSpec::Spec
   endpoint 'Surveys' do |surveys|
 
     surveys.method('Index') do |m|
-
-      m.synopsis = "Shows a list of all surveys for the a site"
-      m.http_method = "GET"
-      m.uri = "/sites/:site_slug/pages/surveys"
+      m.synopsis = 'Shows a list of all surveys for the a site'
+      m.http_method = 'GET'
+      m.uri = '/sites/:site_slug/pages/surveys'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -32,14 +31,12 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'maximum number of results to return'
       end
-
     end
 
     surveys.method('Create') do |m|
-
-      m.synopsis = "Creates a survey for a site"
-      m.http_method = "POST"
-      m.uri = "/sites/:site_slug/pages/surveys"
+      m.synopsis = 'Creates a survey for a site'
+      m.http_method = 'POST'
+      m.uri = '/sites/:site_slug/pages/surveys'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -50,16 +47,14 @@ class ApiSpec::Spec
       m.parameter('body') do |p|
         p.required = 'Y'
         p.type = 'json'
-        p.description = 'a JSON representation of the new survey'
+        p.description = 'A JSON representation of the new survey'
       end
-
     end
 
     surveys.method('Update') do |m|
-
-      m.synopsis = "Updates the attributes of a survey"
-      m.http_method = "PUT"
-      m.uri = "/sites/:site_slug/pages/surveys/:id"
+      m.synopsis = 'Updates the attributes of a survey'
+      m.http_method = 'PUT'
+      m.uri = '/sites/:site_slug/pages/surveys/:id'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -78,14 +73,12 @@ class ApiSpec::Spec
         p.type = 'json'
         p.description = 'JSON containing updates'
       end
-
     end
 
     surveys.method('Destroy') do |m|
-
-      m.synopsis = "Removes a survey"
-      m.http_method = "DELETE"
-      m.uri = "/sites/:site_slug/pages/surveys/:id"
+      m.synopsis = 'Removes a survey'
+      m.http_method = 'DELETE'
+      m.uri = '/sites/:site_slug/pages/surveys/:id'
 
       m.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -98,9 +91,6 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'the ID of the survey'
       end
-
     end
-
   end
-
 end

--- a/lib/api_spec/specs/webhooks.rb
+++ b/lib/api_spec/specs/webhooks.rb
@@ -3,10 +3,9 @@ class ApiSpec::Spec
   endpoint 'Webhooks' do |surveys|
 
     surveys.method('Index') do |m|
-
-      m.synopsis = "Lists all webhooks"
-      m.http_method = "GET"
-      m.uri = "/webhooks"
+      m.synopsis = 'Lists all webhooks'
+      m.http_method = 'GET'
+      m.uri = '/webhooks'
 
       m.parameter('__token') do |p|
         p.required = 'N'
@@ -26,27 +25,24 @@ class ApiSpec::Spec
         p.type = 'int'
         p.description = 'maximum number of results to return'
       end
-
     end
 
     surveys.method('Show') do |m|
-
-      m.synopsis = "Shows the details of an individual webhook"
-      m.http_method = "GET"
-      m.uri = "/webhooks/:id"
+      m.synopsis = 'Shows the details of an individual webhook'
+      m.http_method = 'GET'
+      m.uri = '/webhooks/:id'
 
       m.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'string'
         p.description = 'the ID of the webhook to display'
       end
-
     end
 
     surveys.method('Create') do |m|
-      m.synopsis = "Creates a new webhook"
-      m.http_method = "POST"
-      m.uri = "/webhooks"
+      m.synopsis = 'Creates a new webhook'
+      m.http_method = 'POST'
+      m.uri = '/webhooks'
 
       m.parameter('body') do |p|
         p.required = 'Y'
@@ -56,20 +52,15 @@ class ApiSpec::Spec
     end
 
     surveys.method('Destroy') do |m|
-
-      m.synopsis = "Destroys a webhook"
-      m.http_method = "DELETE"
-      m.uri = "/webhooks/:id"
+      m.synopsis = 'Destroys a webhook'
+      m.http_method = 'DELETE'
+      m.uri = '/webhooks/:id'
 
       m.parameter('id') do |p|
         p.required = 'Y'
         p.type = 'int'
         p.description = 'the ID a webhook'
       end
-
     end
-
   end
-
-
 end

--- a/spec.json
+++ b/spec.json
@@ -119,7 +119,7 @@
       "methods": [
         {
           "MethodName": "Index",
-          "Synopsis": "Shows a list of blog's posts",
+          "Synopsis": "Shows a list of posts for a blog",
           "HTTPMethod": "GET",
           "URI": "/sites/:site_slug/pages/blogs/:id/posts",
           "parameters": [
@@ -781,7 +781,7 @@
               "Required": "Y",
               "Default": "{}",
               "Type": "json",
-              "Description": "JSON representation of a donation"
+              "Description": "a JSON representation of a donation"
             }
           ]
         },
@@ -796,7 +796,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The donation's ID"
+              "Description": "the donation's ID"
             },
             {
               "Name": "body",
@@ -818,7 +818,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The donation's ID"
+              "Description": "the donation's ID"
             }
           ]
         }
@@ -909,7 +909,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "the ID of the event"
+              "Description": "the event's ID"
             }
           ]
         },
@@ -953,7 +953,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The event's ID"
+              "Description": "the event's ID"
             },
             {
               "Name": "body",
@@ -982,7 +982,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The event's ID"
+              "Description": "the event's ID"
             }
           ]
         },
@@ -1004,7 +1004,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The event's ID"
+              "Description": "the event's ID"
             },
             {
               "Name": "__token",
@@ -1047,7 +1047,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The event's ID"
+              "Description": "the event's ID"
             },
             {
               "Name": "body",
@@ -1076,14 +1076,14 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The event's ID"
+              "Description": "the event's ID"
             },
             {
               "Name": "rsvp_id",
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The RSVP's ID"
+              "Description": "the RSVP's ID"
             },
             {
               "Name": "body",
@@ -1150,11 +1150,18 @@
       "name": "Exports",
       "methods": [
         {
-          "MethodName": "Create List",
-          "Synopsis": "Creates a list export with the provided data",
+          "MethodName": "Export List",
+          "Synopsis": "Starts an export of a list",
           "HTTPMethod": "POST",
-          "URI": "/list/:list_id/exports",
+          "URI": "/lists/:list_id/exports",
           "parameters": [
+            {
+              "Name": "list_id",
+              "Required": "Y",
+              "Default": null,
+              "Type": "int",
+              "Description": "ID of the list to export"
+            },
             {
               "Name": "body",
               "Required": "Y",
@@ -1239,7 +1246,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The list's ID"
+              "Description": "the list's ID"
             },
             {
               "Name": "__token",
@@ -1275,7 +1282,7 @@
               "Required": "Y",
               "Default": "{}",
               "Type": "json",
-              "Description": "JSON representation of the list to create"
+              "Description": "a JSON representation of the list to create"
             }
           ]
         },
@@ -1290,7 +1297,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The list's ID"
+              "Description": "the list's ID"
             },
             {
               "Name": "body",
@@ -1312,7 +1319,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The list's ID"
+              "Description": "the list's ID"
             }
           ]
         },
@@ -1327,7 +1334,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The ID of the list"
+              "Description": "the list's ID"
             },
             {
               "Name": "body",
@@ -1349,7 +1356,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The ID of the list"
+              "Description": "the list's ID"
             },
             {
               "Name": "body",
@@ -1371,14 +1378,14 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The ID of the list"
+              "Description": "the list's ID"
             },
             {
               "Name": "person_id",
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The ID of the person to add to the list"
+              "Description": "the ID of the person to add to the list"
             }
           ]
         },
@@ -1393,14 +1400,14 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The ID of the list"
+              "Description": "the list's ID"
             },
             {
               "Name": "person_id",
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The ID of the person to drop from the list"
+              "Description": "the ID of the person to drop from the list"
             }
           ]
         },
@@ -1415,14 +1422,14 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The ID of the list"
+              "Description": "the list's ID"
             },
             {
               "Name": "tag",
               "Required": "Y",
               "Default": null,
               "Type": "string",
-              "Description": "The name of the tag to use"
+              "Description": "the name of the tag to use"
             }
           ]
         },
@@ -1437,14 +1444,14 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The ID of the list"
+              "Description": "the list's ID"
             },
             {
               "Name": "tag",
               "Required": "Y",
               "Default": null,
               "Type": "string",
-              "Description": "The name of the tag to use"
+              "Description": "the name of the tag to use"
             }
           ]
         }
@@ -1464,7 +1471,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The person's ID"
+              "Description": "the person's ID"
             },
             {
               "Name": "__token",
@@ -1500,7 +1507,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The person's ID"
+              "Description": "the person's ID"
             },
             {
               "Name": "body",
@@ -1522,7 +1529,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The person's ID"
+              "Description": "the person's ID"
             },
             {
               "Name": "body",
@@ -1544,14 +1551,14 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The person's ID"
+              "Description": "the person's ID"
             },
             {
               "Name": "name",
               "Required": "Y",
               "Default": null,
               "Type": "string",
-              "Description": "The name of the membership"
+              "Description": "the name of the membership"
             }
           ]
         }
@@ -1571,14 +1578,14 @@
               "Required": "Y",
               "Default": null,
               "Type": "string",
-              "Description": "The slug of the site the page lives on"
+              "Description": "the slug of the site the page lives on"
             },
             {
               "Name": "page_slug",
               "Required": "Y",
               "Default": "1",
               "Type": "string",
-              "Description": "The page's slug"
+              "Description": "the page's slug"
             },
             {
               "Name": "__token",
@@ -1614,21 +1621,21 @@
               "Required": "Y",
               "Default": null,
               "Type": "string",
-              "Description": "The slug of the site the page lives on"
+              "Description": "the slug of the site the page lives on"
             },
             {
               "Name": "page_slug",
               "Required": "Y",
               "Default": "1",
               "Type": "string",
-              "Description": "The page's slug"
+              "Description": "the page's slug"
             },
             {
               "Name": "id",
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The ID of the page attachment"
+              "Description": "the ID of the page attachment"
             }
           ]
         },
@@ -1643,21 +1650,21 @@
               "Required": "Y",
               "Default": null,
               "Type": "string",
-              "Description": "The slug of the site the page lives on"
+              "Description": "the slug of the site the page lives on"
             },
             {
               "Name": "page_slug",
               "Required": "Y",
               "Default": "1",
               "Type": "string",
-              "Description": "The page's slug"
+              "Description": "the page's slug"
             },
             {
               "Name": "body",
               "Required": "Y",
               "Default": "{}",
               "Type": "json",
-              "Description": "A JSON representation of the attachment"
+              "Description": "a JSON representation of the attachment"
             }
           ]
         },
@@ -1672,21 +1679,21 @@
               "Required": "Y",
               "Default": null,
               "Type": "string",
-              "Description": "The slug of the site the page lives on"
+              "Description": "the slug of the site the page lives on"
             },
             {
               "Name": "page_slug",
               "Required": "Y",
               "Default": "1",
               "Type": "string",
-              "Description": "The page's slug"
+              "Description": "the page's slug"
             },
             {
               "Name": "id",
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The ID of the page attachment"
+              "Description": "the ID of the page attachment"
             }
           ]
         }
@@ -1992,7 +1999,7 @@
               "Required": "Y",
               "Default": "34.049031,-118.251399",
               "Type": "string",
-              "Description": "origin of search in the format \"latitude,longitude\""
+              "Description": "origin of search in the format 'latitude,longitude'"
             },
             {
               "Name": "distance",
@@ -2044,7 +2051,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The person's ID"
+              "Description": "the person's id"
             }
           ]
         },
@@ -2059,7 +2066,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "the ID of the person"
+              "Description": "the person's id"
             }
           ]
         },
@@ -2074,7 +2081,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "the ID of the person"
+              "Description": "the person's id"
             },
             {
               "Name": "body",
@@ -2096,7 +2103,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "the ID of the person"
+              "Description": "the person's ID"
             },
             {
               "Name": "tag",
@@ -2118,7 +2125,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "the ID of the person"
+              "Description": "the person's ID"
             },
             {
               "Name": "body",
@@ -2140,7 +2147,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "the ID of the person"
+              "Description": "the person's ID"
             },
             {
               "Name": "__token",
@@ -2176,7 +2183,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "the ID of the person"
+              "Description": "the person's ID"
             },
             {
               "Name": "body",
@@ -2198,7 +2205,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "the ID of the person"
+              "Description": "the person's ID"
             },
             {
               "Name": "capital_id",
@@ -2220,7 +2227,7 @@
               "Required": "Y",
               "Default": "{}",
               "Type": "json",
-              "Description": "JSON representation of the person to create"
+              "Description": "a JSON representation of the person to create"
             }
           ]
         },
@@ -2235,7 +2242,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The person's ID"
+              "Description": "the person's ID"
             },
             {
               "Name": "body",
@@ -2287,7 +2294,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The person's ID"
+              "Description": "the person's ID"
             }
           ]
         },
@@ -2302,14 +2309,14 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "the ID of the person"
+              "Description": "the person's ID"
             },
             {
               "Name": "body",
               "Required": "Y",
               "Default": null,
               "Type": "json",
-              "Description": "JSON representation of the note to create"
+              "Description": "a JSON representation of the note to create"
             }
           ]
         }
@@ -2428,7 +2435,7 @@
               "Required": "Y",
               "Default": "1",
               "Type": "int",
-              "Description": "the precinct's id"
+              "Description": "the precinct's ID"
             }
           ]
         },
@@ -2443,7 +2450,7 @@
               "Required": "Y",
               "Default": "{}",
               "Type": "json",
-              "Description": "JSON representation of the precinct to create"
+              "Description": "a JSON representation of the precinct to create"
             }
           ]
         },
@@ -2458,7 +2465,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The precinct's ID"
+              "Description": "the precinct's ID"
             },
             {
               "Name": "body",
@@ -2480,7 +2487,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "The precinct's ID"
+              "Description": "the precinct's ID"
             }
           ]
         }
@@ -2548,7 +2555,7 @@
               "Required": "N",
               "Default": null,
               "Type": "int",
-              "Description": "the id for a parent survey"
+              "Description": "the ID for a parent survey"
             },
             {
               "Name": "__token",
@@ -2647,7 +2654,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "json",
-              "Description": "a JSON representation of the new survey"
+              "Description": "A JSON representation of the new survey"
             }
           ]
         },


### PR DESCRIPTION
The API Explorer’s `export` endpoint wasn’t working, this should fix that (also should fix the same issue in `nationbuilder-rb` around exports). I took the opportunity to clean up the rest of the code here a bit per some rubocop feedback.

Both the API Explorer and nationbuilder-rb will need to be updated after this goes in.

@kaip @gavindeschutter @sethtrain 
