### PR TITLE
Add blog post show

### DIFF
--- a/lib/api_spec/specs/blog_posts.rb
+++ b/lib/api_spec/specs/blog_posts.rb
@@ -60,7 +60,7 @@ class ApiSpec::Spec
         p.required = 'N'
         p.default = '1'
         p.type = 'int'
-        p.description = 'the external id of the post'
+        p.description = 'the external id of the blog post'
       end
     end
 
@@ -133,7 +133,7 @@ class ApiSpec::Spec
       m.parameter('blog_post_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'the ID of the blog'
+        p.description = 'the ID of the blog post'
       end
 
       m.parameter('body') do |p|
@@ -164,7 +164,7 @@ class ApiSpec::Spec
       m.parameter('blog_post_id') do |p|
         p.required = 'Y'
         p.type = 'int'
-        p.description = 'the ID of the blog'
+        p.description = 'the ID of the blog post'
       end
     end
   end

--- a/lib/api_spec/specs/blog_posts.rb
+++ b/lib/api_spec/specs/blog_posts.rb
@@ -64,6 +64,30 @@ class ApiSpec::Spec
       end
     end
 
+    bp.method('Show') do |m|
+      m.synopsis = 'Show the details of a blog post'
+      m.http_method = 'GET'
+      m.uri = '/sites/:site_slug/pages/blogs/:blog_id/posts/:blog_post_id'
+
+      m.parameter('site_slug') do |p|
+        p.required = 'Y'
+        p.type = 'string'
+        p.description = 'the site holding the blog'
+      end
+
+      m.parameter('blog_id') do |p|
+        p.required = 'Y'
+        p.type = 'int'
+        p.description = 'the ID of the blog'
+      end
+
+      m.parameter('blog_post_id') do |p|
+        p.required = 'Y'
+        p.type = 'int'
+        p.description = 'the ID of the blog post'
+      end
+    end
+
     bp.method('Create') do |m|
       m.synopsis = 'Creates a new blog post'
       m.http_method = 'POST'

--- a/spec.json
+++ b/spec.json
@@ -185,7 +185,36 @@
               "Required": "N",
               "Default": "1",
               "Type": "int",
-              "Description": "the external id of the post"
+              "Description": "the external id of the blog post"
+            }
+          ]
+        },
+        {
+          "MethodName": "Show",
+          "Synopsis": "Show the details of a blog post",
+          "HTTPMethod": "GET",
+          "URI": "/sites/:site_slug/pages/blogs/:blog_id/posts/:blog_post_id",
+          "parameters": [
+            {
+              "Name": "site_slug",
+              "Required": "Y",
+              "Default": null,
+              "Type": "string",
+              "Description": "the site holding the blog"
+            },
+            {
+              "Name": "blog_id",
+              "Required": "Y",
+              "Default": null,
+              "Type": "int",
+              "Description": "the ID of the blog"
+            },
+            {
+              "Name": "blog_post_id",
+              "Required": "Y",
+              "Default": null,
+              "Type": "int",
+              "Description": "the ID of the blog post"
             }
           ]
         },
@@ -243,7 +272,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "the ID of the blog"
+              "Description": "the ID of the blog post"
             },
             {
               "Name": "body",
@@ -279,7 +308,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "int",
-              "Description": "the ID of the blog"
+              "Description": "the ID of the blog post"
             }
           ]
         }


### PR DESCRIPTION
- Add’s the `blog_posts#show` endpoint covered in the API docs [here](https://github.com/3dna/api_docs/blob/master/doc/blog_posts_api.md#show-endpoint).
- Updates descriptions for blog posts endpoints to be consistent (`update`, `destroy`, and `match`).
- Updates the `spec.json` accordingly.

@gavindeschutter @kaip 
