### PR TITLE
Add donations#search endpoint

### DIFF
--- a/lib/api_spec/specs/donations.rb
+++ b/lib/api_spec/specs/donations.rb
@@ -27,6 +27,46 @@ class ApiSpec::Spec
       end
     end
 
+    donation.method('Search') do |method|
+      method.synopsis = 'Search for donations with provided attributes'
+      method.http_method = 'GET'
+      method.uri = '/donations/search'
+
+      method.parameter('created_since') do |p|
+        p.required = 'N'
+        p.type = 'string'
+      end
+
+      method.parameter('succeeded_since') do |p|
+        p.required = 'N'
+        p.type = 'string'
+      end
+
+      method.parameter('failed_since') do |p|
+        p.required = 'N'
+        p.type = 'string'
+      end
+
+      method.parameter('__token') do |p|
+        p.required = 'N'
+        p.type = 'string'
+        p.description = 'pagination token'
+      end
+
+      method.parameter('__nonce') do |p|
+        p.required = 'N'
+        p.type = 'string'
+        p.description = 'pagination nonce'
+      end
+
+      method.parameter('limit') do |p|
+        p.required = 'N'
+        p.default = '10'
+        p.type = 'int'
+        p.description = 'maximum number of results to return'
+      end
+    end
+
     donation.method('Create') do |method|
       method.synopsis = 'Creates a donation with the provided data'
       method.http_method = 'POST'

--- a/spec.json
+++ b/spec.json
@@ -800,6 +800,56 @@
           ]
         },
         {
+          "MethodName": "Search",
+          "Synopsis": "Search for donations with provided attributes",
+          "HTTPMethod": "GET",
+          "URI": "/donations/search",
+          "parameters": [
+            {
+              "Name": "created_since",
+              "Required": "N",
+              "Default": null,
+              "Type": "string",
+              "Description": null
+            },
+            {
+              "Name": "succeeded_since",
+              "Required": "N",
+              "Default": null,
+              "Type": "string",
+              "Description": null
+            },
+            {
+              "Name": "failed_since",
+              "Required": "N",
+              "Default": null,
+              "Type": "string",
+              "Description": null
+            },
+            {
+              "Name": "__token",
+              "Required": "N",
+              "Default": null,
+              "Type": "string",
+              "Description": "pagination token"
+            },
+            {
+              "Name": "__nonce",
+              "Required": "N",
+              "Default": null,
+              "Type": "string",
+              "Description": "pagination nonce"
+            },
+            {
+              "Name": "limit",
+              "Required": "N",
+              "Default": "10",
+              "Type": "int",
+              "Description": "maximum number of results to return"
+            }
+          ]
+        },
+        {
           "MethodName": "Create",
           "Synopsis": "Creates a donation with the provided data",
           "HTTPMethod": "POST",


### PR DESCRIPTION
For context: [Feature announcement](http://nationbuilder.com/api_donation_search_an_update_to_us_political_parties) and [related docs](http://nationbuilder.com/donations_api#search)

Using `string` type to keep consistent with similar endpoints on [people#search](https://github.com/nationbuilder/api_spec/blob/master/lib/api_spec/specs/people.rb#L119-L122).

@fsokhansanj @kaip @asoules