### PR TITLE
Fix Petition uris

### DIFF
--- a/lib/api_spec/specs/petitions.rb
+++ b/lib/api_spec/specs/petitions.rb
@@ -5,7 +5,7 @@ class ApiSpec::Spec
     petition.method('Index') do |method|
       method.synopsis = 'Returns the list of petitions in the site'
       method.http_method = 'GET'
-      method.uri = '/v1/sites/:site_slug/pages/petitions'
+      method.uri = '/sites/:site_slug/pages/petitions'
         
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -36,7 +36,7 @@ class ApiSpec::Spec
     petition.method('Show') do |method|
       method.synopsis = 'Returns data for a single petition'
       method.http_method = 'GET'
-      method.uri = '/v1/sites/:site_slug/pages/petitions/:id'
+      method.uri = '/sites/:site_slug/pages/petitions/:id'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -54,7 +54,7 @@ class ApiSpec::Spec
     petition.method('Create') do |method|
       method.synopsis = 'Creates a new petition'
       method.http_method = 'POST'
-      method.uri = '/v1/sites/:site_slug/pages/petitions'
+      method.uri = '/sites/:site_slug/pages/petitions'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -72,7 +72,7 @@ class ApiSpec::Spec
     petition.method('Update') do |method|
       method.synopsis = 'Updates a single petition'
       method.http_method = 'PUT'
-      method.uri = '/v1/sites/:site_slug/pages/petitions/:id'
+      method.uri = '/sites/:site_slug/pages/petitions/:id'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -96,7 +96,7 @@ class ApiSpec::Spec
     petition.method('Destroy') do |method|
       method.synopsis = 'Removes a petition'
       method.http_method = 'DELETE'
-      method.uri = '/v1/sites/:site_slug/pages/petitions/:id'
+      method.uri = '/sites/:site_slug/pages/petitions/:id'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -114,7 +114,7 @@ class ApiSpec::Spec
     petition.method('Signatures Index') do |method|
       method.synopsis = 'Returns list of signatures in a petition'
       method.http_method = 'GET'
-      method.uri = '/v1/sites/:site_slug/pages/petitions/:petition_id/signatures'
+      method.uri = '/sites/:site_slug/pages/petitions/:petition_id/signatures'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -151,7 +151,7 @@ class ApiSpec::Spec
     petition.method('Show Signature') do |method|
       method.synopsis = 'Returns the signature'
       method.http_method = 'GET'
-      method.uri = '/v1/sites/:site_slug/pages/petitions/:petition_id/signatures/:id'
+      method.uri = '/sites/:site_slug/pages/petitions/:petition_id/signatures/:id'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -175,7 +175,7 @@ class ApiSpec::Spec
     petition.method('Create Signature') do |method|
       method.synopsis = 'Creates a new signature for a petition'
       method.http_method = 'POST'
-      method.uri = '/v1/sites/:site_slug/pages/petitions/:petition_id/signatures'
+      method.uri = '/sites/:site_slug/pages/petitions/:petition_id/signatures'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -199,7 +199,7 @@ class ApiSpec::Spec
     petition.method('Update Signature') do |method|
       method.synopsis = 'Updates a signature for a petition'
       method.http_method = 'POST'
-      method.uri = '/v1/sites/:site_slug/pages/petitions/:petition_id/signatures/:id'
+      method.uri = '/sites/:site_slug/pages/petitions/:petition_id/signatures/:id'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'
@@ -229,7 +229,7 @@ class ApiSpec::Spec
     petition.method('Destroy Signature') do |method|
       method.synopsis = 'Removes signature from petition'
       method.http_method = 'DELETE'
-      method.uri = '/v1/sites/:site_slug/pages/petitions/:petition_id/signatures/:id'
+      method.uri = '/sites/:site_slug/pages/petitions/:petition_id/signatures/:id'
 
       method.parameter('site_slug') do |p|
         p.required = 'Y'

--- a/spec.json
+++ b/spec.json
@@ -2512,7 +2512,7 @@
           "MethodName": "Index",
           "Synopsis": "Returns the list of petitions in the site",
           "HTTPMethod": "GET",
-          "URI": "/v1/sites/:site_slug/pages/petitions",
+          "URI": "/sites/:site_slug/pages/petitions",
           "parameters": [
             {
               "Name": "site_slug",
@@ -2548,7 +2548,7 @@
           "MethodName": "Show",
           "Synopsis": "Returns data for a single petition",
           "HTTPMethod": "GET",
-          "URI": "/v1/sites/:site_slug/pages/petitions/:id",
+          "URI": "/sites/:site_slug/pages/petitions/:id",
           "parameters": [
             {
               "Name": "site_slug",
@@ -2570,7 +2570,7 @@
           "MethodName": "Create",
           "Synopsis": "Creates a new petition",
           "HTTPMethod": "POST",
-          "URI": "/v1/sites/:site_slug/pages/petitions",
+          "URI": "/sites/:site_slug/pages/petitions",
           "parameters": [
             {
               "Name": "site_slug",
@@ -2592,7 +2592,7 @@
           "MethodName": "Update",
           "Synopsis": "Updates a single petition",
           "HTTPMethod": "PUT",
-          "URI": "/v1/sites/:site_slug/pages/petitions/:id",
+          "URI": "/sites/:site_slug/pages/petitions/:id",
           "parameters": [
             {
               "Name": "site_slug",
@@ -2621,7 +2621,7 @@
           "MethodName": "Destroy",
           "Synopsis": "Removes a petition",
           "HTTPMethod": "DELETE",
-          "URI": "/v1/sites/:site_slug/pages/petitions/:id",
+          "URI": "/sites/:site_slug/pages/petitions/:id",
           "parameters": [
             {
               "Name": "site_slug",
@@ -2643,7 +2643,7 @@
           "MethodName": "Signatures Index",
           "Synopsis": "Returns list of signatures in a petition",
           "HTTPMethod": "GET",
-          "URI": "/v1/sites/:site_slug/pages/petitions/:petition_id/signatures",
+          "URI": "/sites/:site_slug/pages/petitions/:petition_id/signatures",
           "parameters": [
             {
               "Name": "site_slug",
@@ -2686,7 +2686,7 @@
           "MethodName": "Show Signature",
           "Synopsis": "Returns the signature",
           "HTTPMethod": "GET",
-          "URI": "/v1/sites/:site_slug/pages/petitions/:petition_id/signatures/:id",
+          "URI": "/sites/:site_slug/pages/petitions/:petition_id/signatures/:id",
           "parameters": [
             {
               "Name": "site_slug",
@@ -2715,7 +2715,7 @@
           "MethodName": "Create Signature",
           "Synopsis": "Creates a new signature for a petition",
           "HTTPMethod": "POST",
-          "URI": "/v1/sites/:site_slug/pages/petitions/:petition_id/signatures",
+          "URI": "/sites/:site_slug/pages/petitions/:petition_id/signatures",
           "parameters": [
             {
               "Name": "site_slug",
@@ -2744,7 +2744,7 @@
           "MethodName": "Update Signature",
           "Synopsis": "Updates a signature for a petition",
           "HTTPMethod": "POST",
-          "URI": "/v1/sites/:site_slug/pages/petitions/:petition_id/signatures/:id",
+          "URI": "/sites/:site_slug/pages/petitions/:petition_id/signatures/:id",
           "parameters": [
             {
               "Name": "site_slug",
@@ -2780,7 +2780,7 @@
           "MethodName": "Destroy Signature",
           "Synopsis": "Removes signature from petition",
           "HTTPMethod": "DELETE",
-          "URI": "/v1/sites/:site_slug/pages/petitions/:petition_id/signatures/:id",
+          "URI": "/sites/:site_slug/pages/petitions/:petition_id/signatures/:id",
           "parameters": [
             {
               "Name": "site_slug",


### PR DESCRIPTION
When we added the Petition docs to this repo, we included an extraneous `/v1/` in the method uris, and now when pulled into API explorer it's making requests to `/v1/v1/`.

This PR removes the extra v1 and re-generates the spec JSON. When this is merged, I'll pull it into API explorer and re-deploy API explorer to fix.