### PR TITLE
Adding a note that person_id is required for RSVPs

### DIFF
--- a/lib/api_spec/specs/events.rb
+++ b/lib/api_spec/specs/events.rb
@@ -194,7 +194,8 @@ class ApiSpec::Spec
       method.parameter('body') do |p|
         p.required = 'Y'
         p.type = 'json'
-        p.description = 'A JSON representation of the new post'
+        p.description = 'A JSON representation of the new post' \
+                        "<br>(Note: 'person_id' attribute is required)"
       end
     end
 
@@ -224,7 +225,8 @@ class ApiSpec::Spec
       method.parameter('body') do |p|
         p.required = 'Y'
         p.type = 'json'
-        p.description = 'JSON attributes for updating the RSVP'
+        p.description = 'JSON attributes for updating the RSVP' \
+                        "<br>(Note: 'person_id' attribute is required)"
       end
     end
   end

--- a/spec.json
+++ b/spec.json
@@ -1133,7 +1133,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "json",
-              "Description": "A JSON representation of the new post"
+              "Description": "A JSON representation of the new post<br>(Note: 'person_id' attribute is required)"
             }
           ]
         },
@@ -1169,7 +1169,7 @@
               "Required": "Y",
               "Default": null,
               "Type": "json",
-              "Description": "JSON attributes for updating the RSVP"
+              "Description": "JSON attributes for updating the RSVP<br>(Note: 'person_id' attribute is required)"
             }
           ]
         }


### PR DESCRIPTION
Adding a helpful note that `person_id` is a required attribute in the body of event rsvp requests.